### PR TITLE
fixed spacing

### DIFF
--- a/client/src/components/ResultsOverview/ResultsOverview.tsx
+++ b/client/src/components/ResultsOverview/ResultsOverview.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export const ResultsOverview: React.FC = () => {
   return (
-    <div className="content-full-width px-2 md:px-4 lg:pl-8 mt-4 md:mt-6">
+    <div className="content-full-width px-2 md:px-4 lg:px-8 mt-4 md:mt-6">
       <div className="bg-gray-2 border border-gray-7 rounded-xl w-full">
         <div className="flex flex-row justify-between px-3 md:px-6 py-2 gap-1.5">
           <div className="flex flex-col items-start justify-start md:gap-1">

--- a/client/src/components/Stats/StatsWeighted.tsx
+++ b/client/src/components/Stats/StatsWeighted.tsx
@@ -35,7 +35,7 @@ export const StatsWeighted: React.FC<StatsWeightedProps> = ({ network }) => {
   }, [_stats]);
 
   return (
-    <div className="content-full-width px-2 md:px-4 lg:px-8 pt-6">
+    <div className="content-full-width px-2 md:px-4 lg:px-8">
       <div className="bg-gray-2 border border-gray-7 rounded-xl w-full">
         <div className="flex flex-col justify-center px-3 md:px-6 py-2 gap-1">
           <div className="flex-col flex md:flex-row items-center justify-between">


### PR DESCRIPTION
This PR fixes the uneven client display. There was a big gap between voting results and voting period components and the results overview component was stretched longer than the rest of the components. Both are fixed in this PR