### PR TITLE
chore: (ci) cancel previous jobs

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -9,6 +9,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: server

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -9,6 +9,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   SKIP_ENV_VALIDATION: 1
 


### PR DESCRIPTION
## Description

Modified the GH actions to cancel running jobs on re-commit, so the CI only runs for the most recent changes.